### PR TITLE
[FEAT] Mock API 작성 및 Swagger 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
 	kotlin("jvm") version "1.9.25"
+	kotlin("kapt") version "2.1.0"
 	kotlin("plugin.jpa") version "1.9.25" apply false
 	kotlin("plugin.spring") version "1.9.25" apply false
 	id("org.springframework.boot") version "3.4.4" apply false
@@ -36,6 +37,7 @@ allprojects {
 
 	tasks.withType<Test> {
 		useJUnitPlatform()
+		systemProperty("user.timezone", "UTC")
 	}
 }
 
@@ -60,7 +62,7 @@ subprojects {
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 

--- a/ecommerce-adapter/build.gradle.kts
+++ b/ecommerce-adapter/build.gradle.kts
@@ -12,6 +12,9 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+
     runtimeOnly("com.mysql:mysql-connector-j")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/ecommerce-adapter/build.gradle.kts
+++ b/ecommerce-adapter/build.gradle.kts
@@ -15,6 +15,10 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:mysql")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.test {

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/EcommerceApplication.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/EcommerceApplication.kt
@@ -1,4 +1,4 @@
-package com.ecommerce
+package com.ecommerce.adapter
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/coupon/CouponApiController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/coupon/CouponApiController.kt
@@ -1,0 +1,41 @@
+package com.ecommerce.adapter.`in`.web.controller.coupon
+
+import com.ecommerce.adapter.`in`.web.dto.coupon.CouponResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "Coupon", description = "쿠폰 관련 API")
+@RequestMapping("/api/v1")
+interface CouponApiController {
+
+    @Operation(summary = "보유 쿠폰 목록 조회", description = "사용자의 보유 쿠폰 목록을 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "성공"),
+            ApiResponse(responseCode = "404", description = "유효하지 않은 사용자 ID")
+        ]
+    )
+    @GetMapping("/users/{userId}/coupons")
+    fun getCoupons(
+        @Parameter(description = "조회할 사용자 ID", example = "1L")
+        @PathVariable userId: Long
+    ): ResponseEntity<com.ecommerce.adapter.`in`.web.dto.ApiResponse<List<CouponResponse>>>
+
+    @Operation(summary = "쿠폰 발급", description = "쿠폰을 발급 받습니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "성공"),
+            ApiResponse(responseCode = "400", description = "쿠폰 소진"),
+            ApiResponse(responseCode = "404", description = "유효하지 않은 사용자 ID")
+        ]
+    )
+    @PostMapping("/users/{userId}/coupons")
+    fun issueCoupon(
+        @RequestBody couponId: Long
+    ): ResponseEntity<com.ecommerce.adapter.`in`.web.dto.ApiResponse<CouponResponse>>
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/coupon/CouponController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/coupon/CouponController.kt
@@ -1,0 +1,59 @@
+package com.ecommerce.adapter.`in`.web.controller.coupon
+
+import com.ecommerce.adapter.`in`.web.dto.ApiResponse
+import com.ecommerce.adapter.`in`.web.dto.coupon.CouponResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+import java.util.Date
+
+@RestController
+@RequestMapping("/api/v1")
+class CouponController: CouponApiController {
+
+    @GetMapping("/users/{userId}/coupons")
+    override fun getCoupons(@PathVariable userId: Long): ResponseEntity<ApiResponse<List<CouponResponse>>> {
+
+        return ResponseEntity.ok().body(
+            ApiResponse.success(
+                listOf(CouponResponse(
+                    1L,
+                    "쿠폰",
+                    "정액",
+                    1000,
+                    1000,
+                    1000,
+                    false,
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    LocalDateTime.now()
+                ))
+            )
+        )
+    }
+
+    @PostMapping("/users/{userId}/coupons")
+    override fun issueCoupon(@RequestBody couponId: Long): ResponseEntity<ApiResponse<CouponResponse>> {
+        return ResponseEntity.ok().body(
+            ApiResponse.success(
+                CouponResponse(
+                    1L,
+                    "쿠폰",
+                    "정액",
+                    1000,
+                    1000,
+                    1000,
+                    false,
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    LocalDateTime.now()
+                )
+            )
+        )
+    }
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/item/ItemApiController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/item/ItemApiController.kt
@@ -1,0 +1,34 @@
+package com.ecommerce.adapter.`in`.web.controller.item
+
+import com.ecommerce.adapter.`in`.web.dto.item.ItemResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Coupon", description = "쿠폰 관련 API")
+@RequestMapping("/api/v1/items")
+interface ItemApiController {
+
+    @Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "성공")
+        ]
+    )
+    @GetMapping
+    fun getItems(): ResponseEntity<com.ecommerce.adapter.`in`.web.dto.ApiResponse<List<ItemResponse>>>
+
+    @Operation(summary = "인기 상품 목록 조회", description = "인기 상품 목록을 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "성공")
+        ]
+    )
+    @GetMapping("/popular")
+    fun getPopularItems(): ResponseEntity<com.ecommerce.adapter.`in`.web.dto.ApiResponse<List<ItemResponse>>>
+
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/item/ItemController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/item/ItemController.kt
@@ -1,0 +1,47 @@
+package com.ecommerce.adapter.`in`.web.controller.item
+
+import com.ecommerce.adapter.`in`.web.dto.ApiResponse
+import com.ecommerce.adapter.`in`.web.dto.item.ItemResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/items")
+class ItemController: ItemApiController {
+
+    @GetMapping
+    override fun getItems(): ResponseEntity<ApiResponse<List<ItemResponse>>> {
+        return ResponseEntity.ok().body(
+            ApiResponse.success(
+                listOf(
+                    ItemResponse(
+                        1L,
+                        "상품명",
+                        30000,
+                        "SELLING",
+                        3
+                    )
+                )
+            )
+        )
+    }
+
+    @GetMapping("/popular")
+    override fun getPopularItems(): ResponseEntity<ApiResponse<List<ItemResponse>>> {
+        return ResponseEntity.ok().body(
+            ApiResponse.success(
+                listOf(
+                    ItemResponse(
+                        1L,
+                        "상품명",
+                        30000,
+                        "SELLING",
+                        3
+                    )
+                )
+            )
+        )
+    }
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/order/OrderApiController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/order/OrderApiController.kt
@@ -1,0 +1,36 @@
+package com.ecommerce.adapter.`in`.web.controller.order
+
+import com.ecommerce.adapter.`in`.web.dto.order.OrderRequest
+import com.ecommerce.adapter.`in`.web.dto.order.OrderResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Order", description = "주문 관련 API")
+@RequestMapping("/api/v1/orders")
+interface OrderApiController {
+
+    @Operation(summary = "주문 생성", description = "주문을 생성합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "성공"),
+            ApiResponse(responseCode = "400", description = "유효하지 않은 사용자 ID"),
+            ApiResponse(responseCode = "400", description = "유효하지 않은 발급 쿠폰 ID"),
+            ApiResponse(responseCode = "400", description = "유효하지 않은 상품 ID"),
+            ApiResponse(responseCode = "400", description = "주문 상품 누락"),
+            ApiResponse(responseCode = "400", description = "주문 상품 수량 누략"),
+            ApiResponse(responseCode = "400", description = "쿠폰 유효기간 만료"),
+            ApiResponse(responseCode = "400", description = "판매 중지 상품"),
+            ApiResponse(responseCode = "400", description = "품절 상품"),
+        ]
+    )
+    @PostMapping
+    fun placeOrder(
+        @RequestBody request: OrderRequest
+    ): ResponseEntity<com.ecommerce.adapter.`in`.web.dto.ApiResponse<OrderResponse>>
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/order/OrderController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/order/OrderController.kt
@@ -1,0 +1,26 @@
+package com.ecommerce.adapter.`in`.web.controller.order
+
+import com.ecommerce.adapter.`in`.web.dto.ApiResponse
+import com.ecommerce.adapter.`in`.web.dto.order.OrderRequest
+import com.ecommerce.adapter.`in`.web.dto.order.OrderResponse
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/orders")
+class OrderController: OrderApiController {
+
+    @PostMapping
+    override fun placeOrder(@RequestBody request: OrderRequest): ResponseEntity<ApiResponse<OrderResponse>> {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ApiResponse.success(
+                OrderResponse(1L)
+            )
+        )
+    }
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/payment/PaymentApiController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/payment/PaymentApiController.kt
@@ -1,0 +1,33 @@
+package com.ecommerce.adapter.`in`.web.controller.payment
+
+import com.ecommerce.adapter.`in`.web.dto.payment.PaymentRequest
+import com.ecommerce.adapter.`in`.web.dto.payment.PaymentResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Payment", description = "결제 관련 API")
+@RequestMapping("/api/v1/payments")
+interface PaymentApiController {
+
+    @Operation(summary = "결제 요청", description = "결제를 요청합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "성공"),
+            ApiResponse(responseCode = "400", description = "유효하지 않은 사용자 ID"),
+            ApiResponse(responseCode = "400", description = "유효하지 않은 주문 ID"),
+            ApiResponse(responseCode = "400", description = "결제 잔액 부족"),
+            ApiResponse(responseCode = "400", description = "유효하지 않은 결제 수단"),
+            ApiResponse(responseCode = "500", description = "PG사 에러"),
+        ]
+    )
+    @PostMapping
+    fun payment(
+        @RequestBody request: PaymentRequest
+    ): ResponseEntity<com.ecommerce.adapter.`in`.web.dto.ApiResponse<PaymentResponse>>
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/payment/PaymentController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/payment/PaymentController.kt
@@ -1,0 +1,27 @@
+package com.ecommerce.adapter.`in`.web.controller.payment
+
+import com.ecommerce.adapter.`in`.web.dto.ApiResponse
+import com.ecommerce.adapter.`in`.web.dto.payment.PaymentRequest
+import com.ecommerce.adapter.`in`.web.dto.payment.PaymentResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/payments")
+class PaymentController: PaymentApiController {
+
+    @PostMapping
+    override fun payment(
+        @RequestBody request: PaymentRequest
+    ): ResponseEntity<ApiResponse<PaymentResponse>> {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ApiResponse.success(
+                PaymentResponse(1L, "결제 완료")
+            )
+        )
+    }
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/point/PointApiController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/point/PointApiController.kt
@@ -1,0 +1,45 @@
+package com.ecommerce.adapter.`in`.web.controller.point
+
+import com.ecommerce.adapter.`in`.web.dto.point.PointResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Point", description = "포인트 관련 API")
+@RequestMapping("/api/v1")
+interface PointApiController {
+
+    @Operation(summary = "포인트 조회", description = "사용자의 포인트 잔액을 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "성공"),
+            ApiResponse(responseCode = "404", description = "유효하지 않은 사용자 ID")
+        ]
+    )
+    @GetMapping("/users/{userId}/points")
+    fun getPoint(
+        @Parameter(description = "조회할 사용자 ID", example = "1L")
+        @PathVariable userId: Long
+    ): ResponseEntity<com.ecommerce.adapter.`in`.web.dto.ApiResponse<PointResponse>>
+
+    @Operation(summary = "포인트 충전", description = "사용자의 포인트를 충전합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "성공"),
+            ApiResponse(responseCode = "400", description = "유효하지 않은 충전 금액"),
+            ApiResponse(responseCode = "404", description = "유효하지 않은 사용자 ID")
+        ]
+    )
+    @PostMapping("/users/{userId}/points")
+    fun chargePoint(
+        @Parameter(description = "충전할 사용자 ID", example = "1L")
+        @PathVariable userId: Long
+    ): ResponseEntity<com.ecommerce.adapter.`in`.web.dto.ApiResponse<PointResponse>>
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/point/PointController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/controller/point/PointController.kt
@@ -1,0 +1,30 @@
+package com.ecommerce.adapter.`in`.web.controller.point
+
+import com.ecommerce.adapter.`in`.web.dto.ApiResponse
+import com.ecommerce.adapter.`in`.web.dto.point.PointResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class PointController: PointApiController {
+
+    @GetMapping("/users/{userId}/points")
+    override fun getPoint(@PathVariable userId: Long): ResponseEntity<ApiResponse<PointResponse>> {
+        return ResponseEntity.ok(
+            ApiResponse.success(PointResponse(1L, 10_000L))
+        )
+    }
+
+    @PostMapping("/users/{userId}/points")
+    override fun chargePoint(@PathVariable userId: Long): ResponseEntity<ApiResponse<PointResponse>> {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ApiResponse.success(PointResponse(1L, 10_000L))
+        )
+    }
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/ApiResponse.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/ApiResponse.kt
@@ -1,0 +1,48 @@
+package com.ecommerce.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "공통 API 응답 모델")
+data class ApiResponse<T>(
+    @field:Schema(description = "성공 여부", type = "Boolean", example = "true")
+    val success: Boolean,
+    @field:Schema(description = "응답 데이터", type = "Object")
+    val data: DataWrapper<T>? = null,
+    @field:Schema(description = "에러 메시지", type = "String")
+    val errorMessage: String? = null
+) {
+
+    data class DataWrapper<T>(
+        @field:Schema(description = "응답 데이터 내용", type = "Object")
+        val content: T,
+        @field:Schema(description = "페이징", type = "Object")
+        val pagination: Pagination? = null
+    )
+
+    data class Pagination(
+        @field:Schema(description = "현재 페이지", type = "Object")
+        val page: Int,
+        @field:Schema(description = "페이지별 데이터 수", type = "Int")
+        val size: Int,
+        @field:Schema(description = "전체 페이지 수", type = "Int")
+        val totalPages: Int,
+        @field:Schema(description = "전체 데이터 수", type = "Long")
+        val totalElements: Long
+    )
+
+    companion object {
+        fun <T> success(content: T, pagination: Pagination? = null): ApiResponse<T> =
+            ApiResponse(
+                success = true,
+                data = DataWrapper(content, pagination),
+                errorMessage = null
+            )
+
+        fun <T> failure(content: T, errorMessage: String? = null): ApiResponse<T> =
+            ApiResponse(
+                success = false,
+                data = null,
+                errorMessage = errorMessage
+            )
+    }
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/coupon/CouponResponse.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/coupon/CouponResponse.kt
@@ -1,0 +1,16 @@
+package com.ecommerce.adapter.`in`.web.dto.coupon
+
+import java.time.LocalDateTime
+
+data class CouponResponse(
+    val id: Long,
+    val name: String,
+    val discountType: String,
+    val discountAmount: Int,
+    val minPayAmount: Int,
+    val maxDiscountAmount: Int,
+    val isUsed: Boolean,
+    val useStartAt: LocalDateTime,
+    val useEndAt: LocalDateTime,
+    val issuedAt: LocalDateTime
+)

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/item/ItemResponse.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/item/ItemResponse.kt
@@ -1,0 +1,10 @@
+package com.ecommerce.adapter.`in`.web.dto.item
+
+data class ItemResponse(
+    val id: Long,
+    val name: String,
+    val price: Int,
+    val status: String,
+    val stock: Int,
+    val salesCount: Int? = null
+)

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/order/OrderRequest.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/order/OrderRequest.kt
@@ -1,0 +1,24 @@
+package com.ecommerce.adapter.`in`.web.dto.order
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "주문 생성 모델")
+data class OrderRequest(
+    @field:Schema(description = "사용자 ID", type = "Long", example = "1L")
+    val userId: Long,
+
+    @field:Schema(description = "발급 쿠폰 ID", type = "Long", example = "1L")
+    val issuedCouponId: Long,
+
+    @field:Schema(description = "주문 상품 목록", type = "Array", example = "1L")
+    val orderItems: List<OrderItemRequest>
+) {
+
+    data class OrderItemRequest(
+        @field:Schema(description = "상품 ID", type = "Long", example = "1L")
+        val itemId: Long,
+
+        @field:Schema(description = "수량", type = "Int", example = "1")
+        val quantity: Int
+    )
+}

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/order/OrderResponse.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/order/OrderResponse.kt
@@ -1,0 +1,5 @@
+package com.ecommerce.adapter.`in`.web.dto.order
+
+data class OrderResponse(
+    val orderId: Long
+)

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/payment/PaymentRequest.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/payment/PaymentRequest.kt
@@ -1,0 +1,15 @@
+package com.ecommerce.adapter.`in`.web.dto.payment
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "결제 요청 모델")
+data class PaymentRequest(
+    @field:Schema(description = "사용자 ID", type = "Long", example = "1L")
+    val userId: Long,
+    @field:Schema(description = "주문 ID", type = "Long", example = "1L")
+    val orderId: Long,
+    @field:Schema(description = "주문 가격", type = "Int", example = "1L")
+    val price: Int,
+    @field:Schema(description = "결제 수단", type = "String", example = "CASH")
+    val paymentMethod: String
+)

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/payment/PaymentResponse.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/payment/PaymentResponse.kt
@@ -1,0 +1,6 @@
+package com.ecommerce.adapter.`in`.web.dto.payment
+
+data class PaymentResponse(
+    val paymentId: Long,
+    val status: String
+)

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/point/PointResponse.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/web/dto/point/PointResponse.kt
@@ -1,0 +1,6 @@
+package com.ecommerce.adapter.`in`.web.dto.point
+
+data class PointResponse(
+    val userId: Long,
+    val amount: Long
+)


### PR DESCRIPTION
## Issue
- #6 
- #7 

## 작업 내용
- Mock API 구현 및 Swagger 적용
    - API 인터페이스를 생성하여 구현부에 Swagger 어노테이션이 침투하지 않도록 관심사 분리하였음.
    - 상품 관련 API 1645632e560d8bec85aa18f1b6c02f975247e5df
    - 포인트 관련 API 7136bbba3b49bdde2d2a7d5b32ad84b5bf28bea1
    - 쿠폰 관련 API 334e50d77505bbbb99afef1acf425effa0f8e51e
    - 주문 관련 API 5736e3bc86188e41a769597ccc8ca0ba4986f56e
    - 결제 관련 API fb1bd72e0b8e1b7a80dabb1a4776f6cea4efaa84